### PR TITLE
Update node engine version

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "src"
   ],
   "engines": {
-    "node": ">=10"
+    "node": "^14 || ^16"
   },
   "scripts": {
     "build": "rollup -c",


### PR DESCRIPTION
The deployment is failing probably because of automatically using the latest node.js version. This PR targets 14.x and 16.x only.

cc: @getdokan/developers 