### PR TITLE
publish publicly to npm

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,5 +1,6 @@
 name: Publish to NPM
 on:
+  workflow_dispatch:
   release:
     types: [created]
 jobs:
@@ -17,13 +18,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '18.x'
-          registry-url: 'https://npm.pkg.github.com'
+          registry-url: 'https://registry.npmjs.org'
           cache: 'pnpm'
       - name: Install dependencies
         run: pnpm install
       - name: Build
         run: pnpm build
       - name: Publish package on NPM
-        run: npm publish
+        run: npm publish --access public
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced manual triggering for the release workflow, enhancing flexibility.
	- Shifted package publication from GitHub's registry to the public NPM registry.
	- Updated publishing command to explicitly set package access to public.
	- Changed authentication method for publishing to align with the new registry.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->