### PR TITLE
update: Added `DokanToaster` and renamed Toast as `useToast`

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -35,7 +35,8 @@ export { default as Loader } from './components/Loader';
 export { default as MaskedInput } from './components/MaskedInput';
 export { default as ConfirmModal } from './components/ConfirmModal';
 export { default as ErrorMessage } from './components/ErrorMessage';
-export { default as Toast } from './components/use-toast.tsx';
+export { default as useToast } from './components/use-toast.tsx';
+export { Toaster as DokanToaster } from 'react-hot-toast';
 
 // Icons
 export { default as ErrorIcon } from './components/icons/ErrorIcon';


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new hook-based export for the `Toast` component, now named `useToast`.
	- Added a new export for `DokanToaster` from the `react-hot-toast` package.

- **Refactor**
	- Organized export statements in ascending order for improved readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->