### PR TITLE
refactor: remove map api key

### DIFF
--- a/src/stories/GooglePlaceAutocomplete.stories.tsx
+++ b/src/stories/GooglePlaceAutocomplete.stories.tsx
@@ -12,7 +12,7 @@ type Story = StoryObj<typeof meta>;
 
 export const Default: Story = {
   args: {
-    apiKey: 'AIzaSyDvqF2TFlH_iL33LMiDHvNpkAcpK0nW7_0',
+    apiKey: '',
     label: 'Address',
   },
   render: (args) => {
@@ -22,7 +22,7 @@ export const Default: Story = {
 
 export const Error: Story = {
   args: {
-    apiKey: 'AIzaSyDvqF2TFlH_iL33LMiDHvNpkAcpK0nW7_0',
+    apiKey: '',
     errors: ['Address is required'],
     label: 'Address',
   },


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Removed the hardcoded Google API key from the GooglePlaceAutocomplete story examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->