### PR TITLE
refactor: update Drawer and Modal components to use onClose prop inst…

### DIFF
--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -10,10 +10,11 @@ export type DrawerProps = Omit<
   direction?: 'ltr' | 'rtl';
   isOpen: boolean;
   children: ReactNode;
-  setIsOpen: (open: boolean) => void;
+  onClose: () => void;
+  className?: string;
 };
 
-export const Drawer = ({ direction = 'ltr', isOpen, setIsOpen, children, ...rest }: DrawerProps) => {
+export const Drawer = ({ direction = 'ltr', isOpen, children, onClose, className, ...rest }: DrawerProps) => {
   // Close button
   const closeButton = (
     <VaulDrawer.Close className="flex pt-5 px-2">
@@ -34,7 +35,7 @@ export const Drawer = ({ direction = 'ltr', isOpen, setIsOpen, children, ...rest
     <VaulDrawer.Root
       key={direction}
       open={isOpen}
-      onOpenChange={setIsOpen}
+      onOpenChange={() => onClose()}
       direction={direction === 'ltr' ? 'right' : 'left'}
       {...rest}
     >
@@ -44,7 +45,8 @@ export const Drawer = ({ direction = 'ltr', isOpen, setIsOpen, children, ...rest
         <VaulDrawer.Content
           className={classNames(
             'fixed top-0 h-full flex z-40 max-w-sm w-full outline-none',
-            direction === 'ltr' ? 'right-0' : 'left-0'
+            direction === 'ltr' ? 'right-0' : 'left-0',
+            className
           )}
         >
           {renderContent()}

--- a/src/components/Drawer.tsx
+++ b/src/components/Drawer.tsx
@@ -10,11 +10,11 @@ export type DrawerProps = Omit<
   direction?: 'ltr' | 'rtl';
   isOpen: boolean;
   children: ReactNode;
-  onClose: () => void;
+  setIsOpen: (open: boolean) => void;
   className?: string;
 };
 
-export const Drawer = ({ direction = 'ltr', isOpen, children, onClose, className, ...rest }: DrawerProps) => {
+export const Drawer = ({ direction = 'ltr', isOpen, setIsOpen, children, className, ...rest }: DrawerProps) => {
   // Close button
   const closeButton = (
     <VaulDrawer.Close className="flex pt-5 px-2">
@@ -35,7 +35,7 @@ export const Drawer = ({ direction = 'ltr', isOpen, children, onClose, className
     <VaulDrawer.Root
       key={direction}
       open={isOpen}
-      onOpenChange={() => onClose()}
+      onOpenChange={setIsOpen}
       direction={direction === 'ltr' ? 'right' : 'left'}
       {...rest}
     >
@@ -45,8 +45,8 @@ export const Drawer = ({ direction = 'ltr', isOpen, children, onClose, className
         <VaulDrawer.Content
           className={classNames(
             'fixed top-0 h-full flex z-40 max-w-sm w-full outline-none',
-            direction === 'ltr' ? 'right-0' : 'left-0',
-            className
+            className,
+            direction === 'ltr' ? 'right-0' : 'left-0'
           )}
         >
           {renderContent()}

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -1,5 +1,5 @@
 import * as Dialog from '@radix-ui/react-dialog';
-import React, { useCallback, memo } from 'react';
+import React, { memo } from 'react';
 import { classNames } from '@/utils';
 
 // ----------- Types -----------
@@ -7,6 +7,7 @@ export type ModalProps = Omit<React.ComponentPropsWithoutRef<typeof Dialog.Conte
   isOpen: boolean;
   onClose: () => void;
   showXButton?: boolean;
+  className?: string;
 };
 
 export type TitleProps = React.ComponentPropsWithoutRef<typeof Dialog.Title>;
@@ -21,13 +22,6 @@ interface ModalComponent extends React.FC<ModalProps> {
 
 // ----------- Root Modal -----------
 const ModalRoot: React.FC<ModalProps> = ({ children, className, isOpen, onClose, showXButton = true, ...rest }) => {
-  const handleOpenChange = useCallback(
-    (open: boolean) => {
-      if (!open) onClose();
-    },
-    [onClose]
-  );
-
   // ----------- Classes -----------
   const overlayClasses =
     'fixed inset-0 z-10 bg-black/25 data-[state=open]:animate-slide-up-fade data-[state=closed]:animate-slide-down-fade-out';
@@ -44,7 +38,7 @@ const ModalRoot: React.FC<ModalProps> = ({ children, className, isOpen, onClose,
     'absolute right-2 top-2 rounded p-1.5 transition-colors duration-150 text-sm text-gray-500 hover:text-gray-700 focus:outline-none';
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={handleOpenChange}>
+    <Dialog.Root open={isOpen} onOpenChange={() => onClose()}>
       <Dialog.Portal>
         <Dialog.Overlay className={overlayClasses} />
         <Dialog.Content className={contentClasses} {...rest}>

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -38,7 +38,12 @@ const ModalRoot: React.FC<ModalProps> = ({ children, className, isOpen, onClose,
     'absolute right-2 top-2 rounded p-1.5 transition-colors duration-150 text-sm text-gray-500 hover:text-gray-700 focus:outline-none';
 
   return (
-    <Dialog.Root open={isOpen} onOpenChange={() => onClose()}>
+    <Dialog.Root
+      open={isOpen}
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
       <Dialog.Portal>
         <Dialog.Overlay className={overlayClasses} />
         <Dialog.Content className={contentClasses} {...rest}>

--- a/src/stories/Drawer.stories.tsx
+++ b/src/stories/Drawer.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story = {
   args: {
     isOpen: true,
     direction: 'ltr',
-    setIsOpen: () => {},
+    onClose: () => {},
   },
 
   render: () => {
@@ -26,7 +26,7 @@ export const Default: Story = {
     return (
       <>
         <Button color="primary" label="Open Drawer" onClick={() => updateArgs({ isOpen: true })}></Button>
-        <Drawer {...args} setIsOpen={() => updateArgs({ isOpen: false })}>
+        <Drawer {...args} onClose={() => updateArgs({ isOpen: false })}>
           <div className="px-6">Drawer Content</div>
         </Drawer>
       </>

--- a/src/stories/Drawer.stories.tsx
+++ b/src/stories/Drawer.stories.tsx
@@ -18,7 +18,7 @@ export const Default: Story = {
   args: {
     isOpen: true,
     direction: 'ltr',
-    onClose: () => {},
+    setIsOpen: () => {},
   },
 
   render: () => {
@@ -26,7 +26,7 @@ export const Default: Story = {
     return (
       <>
         <Button color="primary" label="Open Drawer" onClick={() => updateArgs({ isOpen: true })}></Button>
-        <Drawer {...args} onClose={() => updateArgs({ isOpen: false })}>
+        <Drawer {...args} setIsOpen={() => updateArgs({ isOpen: false })}>
           <div className="px-6">Drawer Content</div>
         </Drawer>
       </>


### PR DESCRIPTION
…ead of setIsOpen

- Replaced setIsOpen with onClose in Drawer component for better clarity and functionality.
- Updated Modal component to use onClose for handling open state changes.
- Added className prop to both components for improved styling flexibility.
- Adjusted related stories to reflect the new prop structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Drawer now supports custom styling via an optional className prop, allowing teams to extend or override visual presentation. The class is applied to the drawer content; opening behavior and controls remain the same.
  - Modal now supports custom styling via an optional className prop, applied to modal content for easier theming. Closing behavior, including controlled isOpen state and the close button, is unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->